### PR TITLE
Supporting retrieval of an arbitrary number of columns when using `get`.

### DIFF
--- a/t/uri_gen.t
+++ b/t/uri_gen.t
@@ -14,7 +14,7 @@ ok(
         'where' => {
                    'key_equals' => 1234567890
         },
-    }) eq q|/my_table/1234567890|
+    })->[0]->{url} eq q|/my_table/1234567890|
     ,
     q|Test simple get|
 );
@@ -27,7 +27,7 @@ ok(
             'key_equals' => 1234567890
         },
         'versions' => 100,
-    }) eq q|/my_table/1234567890?v=100|
+    })->[0]->{url} eq q|/my_table/1234567890?v=100|
     ,
     q|Test versions|
 );
@@ -43,7 +43,7 @@ ok(
             'd:some_column_name',
             'd:some_other_column_name'
         ]
-    }) eq q|/my_table/1234567890/d%3Asome_column_name,d%3Asome_other_column_name|
+    })->[0]->{url} eq q|/my_table/1234567890/d%3Asome_column_name,d%3Asome_other_column_name|
     ,
     q|Test columns|
 );
@@ -60,7 +60,7 @@ ok(
             'd:some_column_name',
             'd:some_other_column_name'
         ]
-    }) eq q|/my_table/1234567890/d%3Asome_column_name,d%3Asome_other_column_name?v=100|
+    })->[0]->{url} eq q|/my_table/1234567890/d%3Asome_column_name,d%3Asome_other_column_name?v=100|
     ,
     q|Test versions and columns|
 );
@@ -81,7 +81,7 @@ ok(
             from  => 1415000000000,
             until => 1415300000000,
         }
-    }) eq q|/my_table/1234567890/d%3Asome_column_name,d%3Asome_other_column_name/1415000000000,1415300000000?v=100|
+    })->[0]->{url} eq q|/my_table/1234567890/d%3Asome_column_name,d%3Asome_other_column_name/1415000000000,1415300000000?v=100|
     ,
     q|Test versions, columns and timestamp range|
 ); 
@@ -98,7 +98,7 @@ ok(
             from  => 1415000000000,
             until => 1415300000000,
         }
-    }) eq q|/my_table/1234567890?v=100|
+    })->[0]->{url} eq q|/my_table/1234567890?v=100|
     ,
     q|Test timestamp range without columns specified|
 );


### PR DESCRIPTION
Retrieval of columns should respect the char limit of the url, if the
length of the columns string will exceed that we need to chunk it up
in order to return the requested columns.

HBase was built to support thousands of columns and this change is necessary
for the JSONRest module to be able to fully utilize the powers of
HBase column capacity.