### PR TITLE
Multiget fixed

### DIFF
--- a/lib/HBase/JSONRest.pm
+++ b/lib/HBase/JSONRest.pm
@@ -542,8 +542,7 @@ sub _build_multiget_uri {
     my $keys  = $query->{where}->{key_in};
     my $table = $query->{table};
 
-    my $route_base = '/' . $table . '/multiget?';
-    my $uri_base = $route_base;
+    my $uri_base = '/' . $table . '/multiget?';
 
     my @multiget_urls = ();
     my $current_url = undef;
@@ -558,7 +557,7 @@ sub _build_multiget_uri {
             }
             else {
                 push @multiget_urls, { url => $current_url, len => length($current_url) };
-                $current_url = undef;
+                $current_url = $uri_base . "row=" . uri_escape($key);
             }
         }
     }

--- a/t/uri_gen.t
+++ b/t/uri_gen.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 10;
 
 use HBase::JSONRest;
 use HBase::JSONRest::Scanner;
@@ -152,3 +152,28 @@ ok(
     q|Test startrow scan|
 );
 
+# 10. multiget: long keys
+is_deeply(
+    [
+        map { $_->{url} }
+        @{ HBase::JSONRest::_build_multiget_uri({
+            'table' => 'my_table',
+            'where' => {
+                'key_in' => [
+                    1 x 1600,
+                    2 x 1600,
+                    3 x 800,
+                    4 x 800,
+                    5 x 800,
+                ]
+            },
+        }) }
+    ],
+    [
+        '/my_table/multiget?row=' . ( 1 x 1600 ),
+        '/my_table/multiget?row=' . ( 2 x 1600 ),
+        '/my_table/multiget?row=' . ( 3 x 800 ) . '&row=' . (4 x 800),
+        '/my_table/multiget?row=' . ( 5 x 800 ),
+    ],
+    q|Test multiget with long ids|
+);


### PR DESCRIPTION
Loop in function _build_multiget_uri lost keys when current url became too long.