### PR TITLE
report errors on multiget

### DIFF
--- a/lib/HBase/JSONRest.pm
+++ b/lib/HBase/JSONRest.pm
@@ -265,6 +265,17 @@ sub multiget {
     my @result = ();
     foreach my $url (@$multiget_urls) {
         my $rows = $self->_multiget_tiny($url->{url});
+        if ($self->{last_error}) {
+            if ($self->{last_error}->{type} eq '404') {
+
+                # if some of the keys don't exists, just ignore it
+                $self->{last_error} = undef;
+
+            } else {
+                #some other error in the middle, fail the whole thing
+                return [];
+            }
+        }
         push @result, @$rows
             if ($rows and @$rows);
     }


### PR DESCRIPTION
When there is an error in a multiget request that is chunked into multiple requests, only the error from the last request is being reported back, and all other errors are being ignored.

themage