### PR TITLE
Order of changelog

### DIFF
--- a/Changes
+++ b/Changes
@@ -103,3 +103,9 @@ Revision history for HBase-JSONRest
         - Fixed a bug in multiget - if some of specified keys are missing they will be ignored
           properly (themage).
 
+0.043  Date/Time: 2015-12-03
+
+        [ENHANCEMENTS]
+        - Added support for gzip content-encoding, to save on bandwidth
+
+

--- a/Changes
+++ b/Changes
@@ -1,25 +1,75 @@
 Revision history for HBase-JSONRest
 
-0.001   Date/time: 2014-07-07
-        First version, released on an unsuspecting world.
+0.043  Date/Time: 2015-12-03
 
-0.002   Date/time: 2014-07-08
-        Added error handling info to pod.
+        [ENHANCEMENTS]
+        - Added support for gzip content-encoding, to save on bandwidth
 
-0.003   Date/time: 2014-07-08
-        Correction to pod Synopsis
 
-0.004   Date/time: 2014-07-11
-        Pod coverage test was failing. Added required pod for constructor method.
+0.042  Date/time: 2015-09-02
 
-0.005   Date/time: 2014-07-21
-        Corrected pod for method calls - use hash refs, not lists for params
+        [BUG FIXES]
+        - Fixed a bug in multiget - if some of specified keys are missing
+          they will be ignored properly (themage).
 
-0.010   Date/time: 2014-08-18
-        Added support for multiget.
 
-0.011   Date/time: 2014-08-19
-        Added uri in error message. Correction in comments for get function.
+0.041  Date/time: 2015-08-31
+
+        [ENHANCEMENTS]
+        - Don't create HTTP::Tiny object in each request. Create it in
+          constructor and keep it in hbase object instance so it can be
+          reused. This means that the same instance of HTTP::Tiny can
+          used for many requests, so connections can be reused.
+        - More debug info for failed requests
+        - Added strict mode. Defaults to false. If activated, the hbase
+          handle will die on unsuccessful request.
+
+        [BUG FIXES]
+        - Allow scans with pefix '0'
+        - Fixed bug in_build_get_uri - lost columns when current url
+          became too long (dtcyganov)
+        - Fixed bug in _build_multiget_uri - lost keys when current url
+          became too long (dtcyganov)
+
+
+0.040  Date/time: 2015-08-09
+
+        [ENHANCEMENTS]
+        - Added support for specifying and retrieving an arbitrary number
+          of columns when using `get` (Tarek Sheasha).
+        - Added support for [startrow, endrow) scanner
+
+        [BUG FIXES]
+        - Fixed a bug for PREFIX scanner - when prefix is depleted, the
+          scanning will stop as it should.
+
+
+0.032   Date/time: 2015-06-19
+
+        [BUG FIXES]
+        - Fixed a bug in scanner which could cause some keys to be skipped
+          due to wrong postix used for the first key of the next batch.
+        - Fixed a bug which prevented keys that begin with 0 to be
+          inserted.
+
+
+0.031   Date/time: 2015-06-16
+
+        [ENHANCEMENTS]
+        - Added uri_gen tests for stateless REST scanners
+
+
+0.030   Date/time: 2015-06-15
+
+        [ENHANCEMENTS]
+        - Added support for stateless REST scanners
+
+
+0.021   Date/time: 2015-04-16
+
+        [BUG FIXES]
+        - Bug fix for missing uri_escape of a key in _build_multiget_uri.
+
 
 0.020   Date/time: 2014-11-11
 
@@ -32,9 +82,10 @@ Revision history for HBase-JSONRest
         - Added support for list of columns in get
         - Added support for number of versions in get
         - Added suport for timestamp range in get
-        - Added test for timestamp range uri generator 
+        - Added test for timestamp range uri generator
         - Added option to override HBase timestamp on put
-        - Standardized structure of error description hash generated in _extract_error_tiny
+        - Standardized structure of error description hash generated
+          in _extract_error_tiny
 
         [BUG FIXES]
         - Bug fix for missing $url param in _extract_error_tiny call.
@@ -46,66 +97,33 @@ Revision history for HBase-JSONRest
         - POD for put with HBase timestamp override
         - POD for delete (Robert Nilsson)
 
-0.021   Date/time: 2015-04-16
 
-        [BUG FIXES]
-        - Bug fix for missing uri_escape of a key in _build_multiget_uri.
-
-0.030   Date/time: 2015-06-15
-
-        [ENHANCEMENTS]
-        - Added support for stateless REST scanners
+0.011   Date/time: 2014-08-19
+        Added uri in error message. Correction in comments for get function.
 
 
-0.031   Date/time: 2015-06-16
-
-        [ENHANCEMENTS]
-        - Added uri_gen tests for stateless REST scanners
-
-0.032   Date/time: 2015-06-19
-
-        [BUG FIXES]
-        - Fixed a bug in scanner which could cause some keys to be skipped due to wrong
-          postix used for the first key of the next batch.
-        - Fixed a bug which prevented keys that begin with 0 to be inserted.
-
-0.040  Date/time: 2015-08-09
-
-        [ENHANCEMENTS]
-        - Added support for specifying and retrieving an arbitrary number
-          of columns when using `get` (Tarek Sheasha).
-        - Added support for [startrow, endrow) scanner
-
-        [BUG FIXES]
-        - Fixed a bug for PREFIX scanner - when prefix is depleted, the scanning
-          will stop as it should.
-
-0.041  Date/time: 2015-08-31
-
-        [ENHANCEMENTS]
-        - Don't create HTTP::Tiny object in each request. Create it in constructori
-          and keep it in hbase object instance so it can be reused. This means that
-          the same instance of HTTP::Tiny can be used for many requests, so
-          connections can be reused.
-        - More debug info for failed requests
-        - Added strict mode. Defaults to false. If activated, the hbase handle
-          will die on unsuccessful request.
-
-        [BUG FIXES]
-        - Allow scans with pefix '0'
-        - Fixed bug in_build_get_uri - lost columns when current url became too long (dtcyganov)
-        - Fixed bug in _build_multiget_uri - lost keys when current url became too long (dtcyganov)
+0.010   Date/time: 2014-08-18
+        Added support for multiget.
 
 
-0.042  Date/time: 2015-09-02
+0.005   Date/time: 2014-07-21
+        Corrected pod for method calls - use hash refs, not lists for
+        params
 
-        [BUG FIXES]
-        - Fixed a bug in multiget - if some of specified keys are missing they will be ignored
-          properly (themage).
 
-0.043  Date/Time: 2015-12-03
+0.004   Date/time: 2014-07-11
+        Pod coverage test was failing. Added required pod for constructor
+        method.
 
-        [ENHANCEMENTS]
-        - Added support for gzip content-encoding, to save on bandwidth
 
+0.003   Date/time: 2014-07-08
+        Correction to pod Synopsis
+
+
+0.002   Date/time: 2014-07-08
+        Added error handling info to pod.
+
+
+0.001   Date/time: 2014-07-07
+        First
 

--- a/lib/HBase/JSONRest.pm
+++ b/lib/HBase/JSONRest.pm
@@ -13,7 +13,7 @@ use Data::Dumper;
 
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError) ;
 
-our $VERSION = "0.042.1";
+our $VERSION = "0.043";
 
 my %INFO_ROUTES = (
     version => '/version',

--- a/lib/HBase/JSONRest.pm
+++ b/lib/HBase/JSONRest.pm
@@ -11,7 +11,9 @@ use JSON::XS qw(decode_json encode_json);
 use Time::HiRes qw(gettimeofday time);
 use Data::Dumper;
 
-our $VERSION = "0.042";
+use IO::Uncompress::Gunzip qw(gunzip $GunzipError) ;
+
+our $VERSION = "0.042.1";
 
 my %INFO_ROUTES = (
     version => '/version',
@@ -195,6 +197,7 @@ sub _get_tiny {
     my $rs = $http->get($url, {
         headers => {
             'Accept' => 'application/json',
+            'Accept-Encoding'   => 'gzip',
         }
     });
 
@@ -209,8 +212,9 @@ sub _get_tiny {
             return undef;
         }
     }
-
-    my $response = decode_json($rs->{content});
+    
+    _maybe_decompress( $rs );
+    my $response = decode_json( $rs->{content} );
 
     my @rows = ();
     foreach my $row (@{$response->{Row}}) {
@@ -301,6 +305,7 @@ sub _multiget_tiny {
     my $rs = $http->get($url, {
         headers => {
             'Accept' => $data_format,
+            'Accept-Encoding'   => 'gzip',
         }
     });
 
@@ -316,6 +321,7 @@ sub _multiget_tiny {
         }
     }
 
+    _maybe_decompress( $rs );
     my $response = decode_json($rs->{content});
 
     my @rows = ();
@@ -699,6 +705,22 @@ sub _extract_error_tiny {
     }
 
     return $error_tiny;
+}
+
+sub _maybe_decompress {
+    my $rs = shift;
+   
+    my $content = $rs->{content};
+    if (    exists $rs->{headers}
+            && exists $rs->{ headers }->{ 'content-encoding' }
+            && $rs->{ headers }->{ 'content-encoding' } eq 'gzip' ) {
+        my ( $content_decompressed, $scalar, $GunzipError );
+        gunzip \$content => \$content_decompressed,
+            MultiStream => 1, Append => 1, TrailingData => \$scalar
+        or die "gunzip failed: $GunzipError\n";
+    
+        $rs->{content} = $content_decompressed;
+    }
 }
 
 1;


### PR DESCRIPTION
I reverted the order of the Changelog items in the Changes files, so that the most recent item is the one on top - easier to read as the project grows (most of the time we just want to know what the most recent changes are).